### PR TITLE
Prevent issue with unicode-letters in the `JJ Abrams` regex

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ function nc (el, opt = {}) {
   // Somewhat arbitrary rule where two letter combos not containing vowels should be capitalized
   // fixes /JJ Abrams/ and /JD Salinger/
   // With some exceptions
-    .replace(/\b[bcdfghjklmnpqrstvwxzBCDFGHJKLMNPQRSTVWXZ]{2}\s/, v => v.toUpperCase())
+    .replace(/(?:^|\\s)[bcdfghjklmnpqrstvwxzBCDFGHJKLMNPQRSTVWXZ]{2}\s/, v => v.toUpperCase())
     .replace(/\bMR\.?\b/, 'Mr')
     .replace(/\bMS\.?\b/, 'Ms')
     .replace(/\bDR\.?\b/, 'Dr')

--- a/test/tests.js
+++ b/test/tests.js
@@ -117,7 +117,7 @@ const combinedFields = [
   'David Albert Huffman', 'Rebecca Heineman', 'Anders Hejlsberg', 'Ted Henter',
   'Andy Hertzfeld', 'Rich Hickey', 'D. Richard Hipp', 'C. A. R. Hoare',
   'James Holmes', 'Grace Hopper', 'Dave Hyatt', 'Miguel de Icaza',
-  'Roberto Ierusalimschy', 'Dan Ingalls', 'Geir Ivarsøy',
+  'Roberto Ierusalimschy', 'Dan Ingalls', 'Geir Ivarsøy', 'Torbjörn Manninger',
   'Kenneth E. Iverson', 'Toru Iwatani', 'Bo Jangeborg', 'Paul Jardetzky',
   'Lynne Jolitz', 'William Jolitz', 'Stephen C. Johnson', 'Bill Joy',
   'Robert K. Jung', 'Poul-Henning Kamp', 'Mitch Kapor', 'Phil Katz',


### PR DESCRIPTION
We're seeing issues related to formating scandinavian names containing unicode letters such as `å` and `ö`.

We're seeing results such as:
- `TORBJÖRN M...` becoming `TorbjöRN M...` (Notice the `RN`)
- `ENESGÅRD F...` becoming `EnesgåRD F...` (Notice the `RD`)

We narrowed it down to this section that deals with uppercasing two-letter combos.
It's using `\b` to indicate the word boundary, but since the nordic letters are not being recognised by the RegEx engine, they are treated as word boundaries instead.

Using `(?:^|\\s)` instead should fix this issue.